### PR TITLE
fix currentUser not found error

### DIFF
--- a/javascripts/discourse/components/search-banner.js
+++ b/javascripts/discourse/components/search-banner.js
@@ -31,9 +31,9 @@ export default Component.extend({
     const showFor = settings.show_for;
     if (showFor == "everyone") {
       return true;
-    } else if (showFor == "logged_out" && !currentUser) {
+    } else if (showFor == "logged_out" && !this.currentUser) {
       return true;
-    } else if (showFor == "logged_in" && currentUser) {
+    } else if (showFor == "logged_in" && this.currentUser) {
       return true;
     }
     return false;

--- a/javascripts/discourse/components/search-banner.js
+++ b/javascripts/discourse/components/search-banner.js
@@ -27,13 +27,13 @@ export default Component.extend({
   },
 
   @discourseComputed("currentUser")
-  displayForUser() {
+  displayForUser(currentUser) {
     const showFor = settings.show_for;
     if (showFor == "everyone") {
       return true;
-    } else if (showFor == "logged_out" && !this.currentUser) {
+    } else if (showFor == "logged_out" && !currentUser) {
       return true;
-    } else if (showFor == "logged_in" && this.currentUser) {
+    } else if (showFor == "logged_in" && currentUser) {
       return true;
     }
     return false;


### PR DESCRIPTION
Had a report of an error here: https://meta.discourse.org/t/search-banner-theme-component/122939/37?u=awesomerobot

updating `currentUser` to `this.currentUser` fixed it