### PR TITLE
FIX: Remove `clickOutside` event

### DIFF
--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -35,11 +35,6 @@ export default apiInitializer("0.8", (api) => {
         return this._super(attrs, state);
       }
     },
-    clickOutside() {
-      if (!this.vnode.hooks["widget-mouse-down-outside"]) {
-        return this.mouseDownOutside();
-      }
-    },
     mouseDownOutside() {
       const formFactor = this.state.formFactor;
       if (formFactor === "menu") {


### PR DESCRIPTION
No longer needed since it's removed in core
See https://github.com/discourse/discourse/pull/14788