### PR TITLE
DEV: Do not reuse core's element ID for the input

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -41,6 +41,9 @@ $max-width: 600px;
     position: relative;
     display: flex;
     input[type="text"] {
+      border-width: 0;
+      margin-bottom: 0;
+      flex-grow: 1;
       margin: 0;
       width: 100%;
       padding-right: 4em;

--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -18,6 +18,10 @@ export default apiInitializer("0.8", (api) => {
   const searchMenuWidget = api.container.factoryFor("widget:search-menu");
   const corePanelContents = searchMenuWidget.class.prototype["panelContents"];
 
+  api.reopenWidget("search-term", {
+    buildId: () => "search-banner-term",
+  });
+
   api.reopenWidget("search-menu", {
     buildKey(attrs) {
       let type = attrs.formFactor || "menu";


### PR DESCRIPTION
This changes `search-term` widget's ID for the input so that we do not
include two elements with the same ID in the DOM.