### PR TITLE
UX: let search button click through to full search

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -78,6 +78,9 @@ $max-width: 600px;
     order: 2;
     right: 0;
     background: transparent;
+    .d-icon {
+      margin: 0;
+    }
     .discourse-no-touch & {
       &:hover {
         background: transparent;

--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -1,5 +1,6 @@
 import { apiInitializer } from "discourse/lib/api";
 import { logSearchLinkClick } from "discourse/lib/search";
+import { iconNode } from "discourse-common/lib/icon-library";
 
 export default apiInitializer("0.8", (api) => {
   const enableConnectorName = settings.plugin_outlet;
@@ -111,10 +112,11 @@ export default apiInitializer("0.8", (api) => {
 
       if (formFactor === "widget") {
         contents.push(
-          this.attach("button", {
-            icon: "search",
-            className: "search-icon",
-            action: "showResults",
+          this.attach("link", {
+            href: this.fullSearchUrl({ expanded: true }),
+            contents: () => iconNode("search"),
+            className: "btn search-icon",
+            title: "search.open_advanced",
           })
         );
       }


### PR DESCRIPTION
The search button doesn't do anything at the moment, so this makes it click through to the full search page. 

Originally reported here: https://meta.discourse.org/t/search-banner/122939/99?u=awesomerobot