### PR TITLE
UX: add optional search button text

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -72,20 +72,24 @@ $max-width: 600px;
     text-align: center;
   }
 
-  .search-icon {
+  .btn.search-icon {
     position: absolute;
     z-index: 2;
     order: 2;
     right: 0;
     background: transparent;
+    padding-top: 0.6em;
+    line-height: 1;
+    color: var(--primary-high);
     .d-icon {
-      margin: 0;
+      margin: 0 0 0 0.33em;
     }
     .discourse-no-touch & {
       &:hover {
         background: transparent;
+        color: var(--primary);
         .d-icon {
-          color: var(--primary-high);
+          color: currentColor;
         }
       }
     }

--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -2,6 +2,7 @@ import { apiInitializer } from "discourse/lib/api";
 import { logSearchLinkClick } from "discourse/lib/search";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { h } from "virtual-dom";
+import I18n from "I18n";
 
 export default apiInitializer("0.8", (api) => {
   const enableConnectorName = settings.plugin_outlet;

--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -1,6 +1,7 @@
 import { apiInitializer } from "discourse/lib/api";
 import { logSearchLinkClick } from "discourse/lib/search";
 import { iconNode } from "discourse-common/lib/icon-library";
+import { h } from "virtual-dom";
 
 export default apiInitializer("0.8", (api) => {
   const enableConnectorName = settings.plugin_outlet;
@@ -114,7 +115,13 @@ export default apiInitializer("0.8", (api) => {
         contents.push(
           this.attach("link", {
             href: this.fullSearchUrl({ expanded: true }),
-            contents: () => iconNode("search"),
+            contents: () => [
+              h(
+                "span",
+                I18n.t(themePrefix("search_banner.search_button_text"))
+              ),
+              iconNode("search"),
+            ],
             className: "btn search-icon",
             title: "search.open_advanced",
           })

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,3 +2,4 @@ en:
   search_banner:
     headline: "Welcome to our community"
     subhead: "We're happy to have you here. If you need help, please search before you post."
+    search_button_text: ""


### PR DESCRIPTION
This adds an optional translation, default empty, so admins can add text to the search button like so: 

![Screenshot 2023-07-27 at 9 13 54 AM](https://github.com/discourse/discourse-search-banner/assets/1681963/9a66e3ed-66ef-4afe-bec3-04a47f19c936)
