### PR TITLE
DEV: Use new i18n package

### DIFF
--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -2,7 +2,7 @@ import { apiInitializer } from "discourse/lib/api";
 import { logSearchLinkClick } from "discourse/lib/search";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { h } from "virtual-dom";
-import I18n from "I18n";
+import I18n from "discourse-i18n";
 import SearchBanner from "../components/search-banner";
 
 export default apiInitializer("1.14.0", (api) => {


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/23867

We are moving from "I18n" to "discourse-i18n"