### PR TITLE
FIX: Force search menu to always be displayed as a dropdown

### DIFF
--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -8,4 +8,6 @@ export default apiInitializer("1.14.0", (api) => {
       : "below-site-header",
     SearchBanner
   );
+
+  api.forceDropdownForMenuPanels("search-menu-panel");
 });


### PR DESCRIPTION
Raised in https://meta.discourse.org/t/search-banner/122939/109?u=isaac

> a dark overlay comes over the entire site page and i’m unable to navigate the site

Force the search menu to always render as a dropdown and don't apply the `slide out` styling (dark overlay).

# Before

https://github.com/discourse/discourse-search-banner/assets/50783505/17a5009b-d0c5-40c8-95a5-b00a0685970c


# After

https://github.com/discourse/discourse-search-banner/assets/50783505/4962728f-759b-41bc-af49-6bdc5fe209f7

