### PR TITLE
FIX: don't use fallback key as button text

### DIFF
--- a/javascripts/discourse/components/search-banner.js
+++ b/javascripts/discourse/components/search-banner.js
@@ -40,7 +40,17 @@ export default class SearchBanner extends Component {
   }
 
   get buttonText() {
-    return I18n.t(themePrefix("search_banner.search_button_text"));
+    const buttonText = themePrefix("search_banner.search_button_text");
+
+    // this is required for when the English (US) locale is empty
+    // and the site locale is set to another language
+    // otherwise the English (US) fallback key is rendered as the button text
+    // https://meta.discourse.org/t/bug-with-search-banner-search-button-text-shown-in-search-banner-theme-component/273628
+    if (buttonText.includes("theme_translations")) {
+      return false;
+    }
+  
+    return  I18n.t(buttonText);
   }
 
   get shouldDisplay() {

--- a/javascripts/discourse/components/search-banner.js
+++ b/javascripts/discourse/components/search-banner.js
@@ -49,8 +49,8 @@ export default class SearchBanner extends Component {
     if (buttonText.includes("theme_translations")) {
       return false;
     }
-  
-    return  I18n.t(buttonText);
+
+    return I18n.t(buttonText);
   }
 
   get shouldDisplay() {

--- a/javascripts/discourse/components/search-banner.js
+++ b/javascripts/discourse/components/search-banner.js
@@ -40,8 +40,7 @@ export default class SearchBanner extends Component {
   }
 
   get buttonText() {
-    const buttonText = themePrefix("search_banner.search_button_text");
-
+    const buttonText = I18n.t(themePrefix("search_banner.search_button_text"));
     // this is required for when the English (US) locale is empty
     // and the site locale is set to another language
     // otherwise the English (US) fallback key is rendered as the button text
@@ -50,7 +49,7 @@ export default class SearchBanner extends Component {
       return false;
     }
 
-    return I18n.t(buttonText);
+    return buttonText;
   }
 
   get shouldDisplay() {


### PR DESCRIPTION
When a non-US locale is the site's default, and the user chooses a US locale, the button would render the fallback key when no translation is set: 

Before:
![image](https://github.com/discourse/discourse-search-banner/assets/1681963/8bfcb9cc-5409-4537-8138-0ecf31d66ba8)

After:
![image](https://github.com/discourse/discourse-search-banner/assets/1681963/ab3d015c-cfb8-4eb9-8ab6-09b868b632ff)


So I've added a check for the default key, which should be considered false. 

Originally reported here: https://meta.discourse.org/t/bug-with-search-banner-search-button-text-shown-in-search-banner-theme-component/273628


I think this is because the translation is being used in an unexpected way as a pseudo-setting (i.e., if it's empty, don't render the button) 