### PR TITLE
UX: fix button alignment, remove dead CSS

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -62,7 +62,6 @@ $max-width: 600px;
   }
 
   .search-input {
-    flex: 1 1 auto;
     #search-term {
       min-width: 0;
       flex: 1 1;

--- a/common/common.scss
+++ b/common/common.scss
@@ -45,6 +45,7 @@ $max-width: 600px;
 
     .search-menu-container {
       width: 100%;
+      min-width: 0;
     }
   }
 
@@ -59,16 +60,12 @@ $max-width: 600px;
   .browser-search-tip {
     display: none;
   }
-  .search-input input#search-term[type="text"] {
-    margin: 0;
-    width: 100%;
-  }
 
   .search-input {
     flex: 1 1 auto;
-    margin: 0;
-    .searching {
-      display: flex;
+    #search-term {
+      min-width: 0;
+      flex: 1 1;
     }
   }
 
@@ -124,13 +121,6 @@ $max-width: 600px;
     }
   }
 
-  // hide the search icon when a search context is selected
-  // eg when searching in a topic
-  .search-input .search-context + .search-icon:not(.has-search-button-text),
-  .search-input .search-context ~ .search-icon:not(.has-search-button-text) {
-    display: none;
-  }
-
   .results {
     box-sizing: border-box;
     background: var(--secondary);
@@ -154,10 +144,6 @@ $max-width: 600px;
     .d-icon-search {
       display: none;
     }
-  }
-
-  .searching a.show-advanced-search {
-    display: none;
   }
 
   .search-link .d-icon {

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -9,7 +9,3 @@
 .search-menu .search-input input#search-term {
   width: 100%;
 }
-
-.custom-search-banner-wrap .search-icon {
-  top: 0.15em;
-}


### PR DESCRIPTION
This fixes the clear and advanced search icon centering, and removes some dead CSS


This was an alignment fix for mobile that's no longer necessary (and causes a slight misalignment)
```scss
.custom-search-banner-wrap .search-icon {
  top: 0.15em;
}
```

This is done in the core search component
```scss
 .searching a.show-advanced-search {
    display: none;
  }
```

These css selectors are not siblings, so the CSS is never applied 
```scss
 // hide the search icon when a search context is selected
  // eg when searching in a topic
  .search-input .search-context + .search-icon:not(.has-search-button-text),
  .search-input .search-context ~ .search-icon:not(.has-search-button-text) {
    display: none;
  }
```

The parent element is no longer flex, so this isn't applied
```scss
.search-input {
    flex: 1 1 auto;
}
```



Before:
![image](https://github.com/discourse/discourse-search-banner/assets/1681963/90940b5c-c7dd-43da-b779-7cc2e9c53afc)



After:
![image](https://github.com/discourse/discourse-search-banner/assets/1681963/6ca3083f-d491-4285-aa6f-0795ca00a25f)

