### PR TITLE
UX: fix alignment for RTL languages

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -87,8 +87,13 @@ $max-width: 600px;
     line-height: 1;
     color: var(--primary-medium);
     height: 100%;
-    padding-right: 0.25em;
     position: absolute;
+    left: 0;
+    .rtl & {
+      right: 0;
+      left: unset;
+    }
+
     .discourse-no-touch & {
       &:hover {
         background: transparent;
@@ -100,6 +105,10 @@ $max-width: 600px;
     }
     + .search-menu-container .search-input {
       padding-left: 1.75em;
+      .rtl & {
+        padding-left: unset;
+        padding-right: 1.75em;
+      }
     }
     + .search-menu-container .search-input .search-context {
       margin-left: 4px;


### PR DESCRIPTION
These styles get a little complex and weren't working properly in RTL locales... 


Before:
![image](https://github.com/user-attachments/assets/3b0082a5-f5d8-4cb0-9048-05e3f48a672a)


After: 
![image](https://github.com/user-attachments/assets/af1d5b99-0997-437c-9bd1-9f8bcd245358)


No changes in LTR: 

![image](https://github.com/user-attachments/assets/c1e0ea70-2623-4b67-a10a-da5bfda21255)
