### PR TITLE
DEV: Update theme name to Advanced Search Banner

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,8 +1,8 @@
 {
-  "name": "Search Banner",
+  "name": "Advanced Search Banner",
   "component": true,
-  "about_url": "https://meta.discourse.org/t/search-banner-theme-component/122939",
-  "license_url": "https://github.com/discourse/discourse-search-banner/blob/master/LICENSE",
+  "about_url": "https://meta.discourse.org/t/-/122939",
+  "license_url": "https://github.com/discourse/discourse-search-banner/blob/main/LICENSE",
   "assets": {},
   "color_schemes": {}
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -163,5 +163,9 @@ $max-width: 600px;
   }
 }
 
+.welcome-banner {
+  display: none;
+}
+
 // these are add-on styles controlled by settings
 @import "special-styles";

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,3 +3,5 @@ en:
     headline: "Welcome to our community"
     subhead: "We're happy to have you here. If you need help, please search before you post."
     search_button_text: ""
+  theme_metadata:
+    description: "Advanced Search Banner puts a search bar along with optional headline and subhead text in a banner above the main topic list navigation"

--- a/spec/system/viewing_search_banner_spec.rb
+++ b/spec/system/viewing_search_banner_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Viewing the search banner", type: :system do
   fab!(:topic)
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
-  xit "should display the search banner below the site header when `plugin_outlet` theme setting is set to `below-site-header`" do
+  it "should display the search banner below the site header when `plugin_outlet` theme setting is set to `below-site-header`" do
     theme.update_setting(:plugin_outlet, "below-site-header")
     theme.save!
 
@@ -15,7 +15,7 @@ RSpec.describe "Viewing the search banner", type: :system do
     expect(page).to_not have_css("#main-outlet .custom-search-banner")
   end
 
-  xit "should display the search banner above the main container when `plugin_outlet` theme setting is set to `above-main-container`" do
+  it "should display the search banner above the main container when `plugin_outlet` theme setting is set to `above-main-container`" do
     theme.update_setting(:plugin_outlet, "above-main-container")
     theme.save!
 
@@ -24,7 +24,7 @@ RSpec.describe "Viewing the search banner", type: :system do
     expect(page).to have_css("#main-outlet .custom-search-banner")
   end
 
-  xit "should display the search icon when searching within a topic when search button text is present" do
+  it "should display the search icon when searching within a topic when search button text is present" do
     theme.update_setting(:show_on, "all")
     theme.update_translation("search_banner.search_button_text", "Foo")
     theme.save!

--- a/test/acceptance/search-banner-test.js
+++ b/test/acceptance/search-banner-test.js
@@ -2,10 +2,10 @@ import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 
-acceptance("Discourse Search Banner", function (needs) {
+acceptance("Discourse Advanced Search Banner", function (needs) {
   needs.user({ admin: true, experimental_search_menu_groups_enabled: true });
 
-  test("Search Banner is present", async function (assert) {
+  test("Advanced Search Banner is present", async function (assert) {
     await visit("/");
     assert.dom(".custom-search-banner input#search-term").exists();
   });


### PR DESCRIPTION
Since we are moving a simplified version of this
into core at https://github.com/discourse/discourse/pull/31516,
this component becomes Advanced Search Banner.

The core welcome banner will be hidden if this
component is installed.

This commit also re-enables previously disabled
specs that would have failed the core PR.
