### PR TITLE
UX: Add wrap class back

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -58,6 +58,10 @@
     }
   }
 
+  h1 {
+    text-align: center;
+  }
+
   .btn.search-icon.has-search-button-text {
     margin-left: 0.5em;
     column-gap: 0.5em;

--- a/javascripts/discourse/components/search-banner.hbs
+++ b/javascripts/discourse/components/search-banner.hbs
@@ -8,7 +8,7 @@
       {{did-insert this.didInsert}}
       {{will-destroy this.willDestroy}}
     >
-      <div class="custom-search-banner-wrap welcome-banner__wrap">
+      <div class="wrap custom-search-banner-wrap welcome-banner__wrap">
         <h1>{{html-safe (theme-i18n "search_banner.headline")}}</h1>
         <PluginOutlet @name="search-banner-below-headline" />
         <p>{{html-safe (theme-i18n "search_banner.subhead")}}</p>


### PR DESCRIPTION
This PR adds the wrap class back into the theme in order to un-break themes relying on it.