### PR TITLE
UX: show search input on narrow screens

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -90,3 +90,8 @@
     padding: 2.5em var(--d-wrap-padding-h) 3em;
   }
 }
+
+// fixes core style clash that hides the banner on narrow screens
+.custom-search-banner .welcome-banner__wrap .search-menu {
+  display: flex;
+}


### PR DESCRIPTION
Some core styles seem to be hiding this when they shouldn't be... will have to investigate, but this fixes for now

Before: 
![image](https://github.com/user-attachments/assets/d8e200f2-5165-4106-8470-2d9706dd7e9f)


After:
![image](https://github.com/user-attachments/assets/bf10da80-8f5e-4f5b-9442-4517119ada87)
