### PR TITLE
FIX: Center paragraph text

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -99,3 +99,7 @@
 .custom-search-banner .welcome-banner__wrap .search-menu {
   display: flex;
 }
+
+.custom-search-banner-wrap p {
+  text-align: center;
+}


### PR DESCRIPTION
The paragraph below the welcome headline was left-aligned, causing a visual inconsistency with the rest of the centered content. This change applies `text-align: center` to the paragraph to fix the layout. 
Ref. https://meta.discourse.org/t/-/374631