### PR TITLE
FIX: restore padding broken due to missing variable

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -88,10 +88,10 @@
 }
 
 .custom-search-banner-wrap {
-  padding: 1em var(--d-wrap-padding-h) 1.25em;
+  padding: 1em 0.67em 1.25em;
 
   @include viewport.from(sm) {
-    padding: 2.5em var(--d-wrap-padding-h) 3em;
+    padding: 2.5em 0.67em 3em;
   }
 }
 


### PR DESCRIPTION
This variable was changed in core and broke the entire padding declaration, better to just avoid that. 


Before: 
<img width="1684" height="422" alt="image" src="https://github.com/user-attachments/assets/8bfbc495-6c65-4e4a-97bd-19f61f6ba813" />


After:
<img width="1690" height="604" alt="image" src="https://github.com/user-attachments/assets/ef99d265-07c7-41bf-8ab6-f63f7d77f351" />
