### PR TITLE
DEV: Add deprecation in readme and global notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,5 @@
-This is a component that puts a search bar along with optional headline and subhead text in a banner above the main topic list navigation of a Discourse community.
+## DEPRECATED
 
-By default this banner appears on all top-level topic pages (latest/new/unread/top/categories... anything in the `top menu` site setting) but it can also be set to only display on a community's homepage.
+This theme component is now deprecated in favor of the core `welcome_banner` functionality.
 
-![screenshot](https://user-images.githubusercontent.com/5862206/214549198-419cb28d-efea-43a3-a273-9fd9617de030.png)
-
-:building_construction: [Github repo](https://github.com/discourse/discourse-search-banner): `https://github.com/discourse/discourse-search-banner`
-
-:telescope: [Preview it on theme creator](https://theme-creator.discourse.org/theme/awesomerobot/discourse-search-banner)
-
-:question: [How do I install a theme component?](https://meta.discourse.org/t/how-do-i-install-a-theme-or-theme-component/63682)
-
-:sparkling_heart: This very heavily borrows from [angus'](https://github.com/angusmcleod) header search component: https://meta.discourse.org/t/header-search-theme/67959
-
-### Available settings
-
-- Set the headline and subhead text
-- Show the banner on all top-level topic pages (default), or just the homepage
-- Set a background image
-
-### Custom styling
-
-The HTML element gets a class named `.display-search-banner` wherever this banner appears, and the banner itself is wrapped with the `.custom-search-banner` class, so with some CSS you should be able to customize the appearance of this banner however you see fit.
-
-### Future enhancements
-
-- Add an option to enable the banner in specific categories
+See [https://meta.discourse.org/t/creating-a-banner-to-display-at-the-top-of-your-site/153718](https://meta.discourse.org/t/creating-a-banner-to-display-at-the-top-of-your-site/153718) for more information.

--- a/javascripts/discourse/api-initializers/init-search-banner.js
+++ b/javascripts/discourse/api-initializers/init-search-banner.js
@@ -1,4 +1,6 @@
+import { addGlobalNotice } from "discourse/components/global-notice";
 import { apiInitializer } from "discourse/lib/api";
+import getURL from "discourse/lib/get-url";
 import SearchBanner from "../components/search-banner";
 
 export default apiInitializer((api) => {
@@ -10,4 +12,20 @@ export default apiInitializer((api) => {
   );
 
   api.forceDropdownForMenuPanels("search-menu-panel");
+
+  if (api.getCurrentUser()?.admin) {
+    const themeId = themePrefix("foo").match(
+      /theme_translations\.(\d+)\.foo/
+    )[1];
+    const themeURL = getURL(`/admin/customize/themes/${themeId}`);
+    addGlobalNotice(
+      `<b>Admin notice:</b> you're using the <em>Advanced Search Banner</em> theme component. This functionality is replaced now with the "welcome banner" functionality in Discourse core. You should <a href="${themeURL}">remove this theme component</a>, and see <a href="https://meta.discourse.org/t/creating-a-banner-to-display-at-the-top-of-your-site/153718" target="_blank">creating a banner to display at the top of your site on Discourse Meta</a> for instructions on how to replace it.`,
+      "advanced-search-banner-deprecation",
+      {
+        dismissable: true,
+        level: "warn",
+        dismissDuration: moment.duration("1", "hour"),
+      }
+    );
+  }
 });


### PR DESCRIPTION
This component is no longer supported and has been
superseded by the core welcome banner, see
https://meta.discourse.org/t/creating-a-banner-to-display-at-the-top-of-your-site/153718
